### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
I understand people often have `node_modules` in their global ignore, but not every body does, and semantically it makes sense to keep this with the project.