### PR TITLE
Add support for bracket notation

### DIFF
--- a/test/brfs.js
+++ b/test/brfs.js
@@ -115,6 +115,48 @@ test('readFileSync attribute with multiple require vars x5', function (t) {
     }));
 });
 
+test('readFileSync with bracket notation', function (t) {
+    t.plan(2);
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, { vars: { __dirname: path.join(__dirname, 'brfs') } });
+    readStream('brackets.js').pipe(sm).pipe(concat(function (body) {
+        t.equal(body.toString('utf8'),
+            '\nvar src = "beep boop\\n";'
+            + '\nconsole.log(src);\n'
+        );
+        vm.runInNewContext(body.toString('utf8'), {
+            console: { log: log }
+        });
+        function log (msg) { t.equal(msg, 'beep boop\n') }
+    }));
+});
+
+test('readFileSync attribute bracket notation', function (t) {
+    t.plan(2);
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, { vars: { __dirname: path.join(__dirname, 'brfs') } });
+    readStream('attribute_brackets.js').pipe(sm).pipe(concat(function (body) {
+        t.equal(body.toString('utf8'),
+            '\nvar src = "beep boop\\n";'
+            + '\nconsole.log(src);\n'
+        );
+        vm.runInNewContext(body.toString('utf8'), {
+            console: { log: log }
+        });
+        function log (msg) { t.equal(msg, 'beep boop\n') }
+    }));
+});
+
 function readStream (file) {
     return fs.createReadStream(path.join(__dirname, 'brfs', file));
 }

--- a/test/brfs/attribute_brackets.js
+++ b/test/brfs/attribute_brackets.js
@@ -1,0 +1,3 @@
+var f = require('fs')["readFileSync"];
+var src = f(__dirname + '/x.txt', 'utf8');
+console.log(src);

--- a/test/brfs/brackets.js
+++ b/test/brfs/brackets.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+var src = fs["readFileSync"](__dirname + '/x.txt', 'utf8');
+console.log(src);


### PR DESCRIPTION
This adds support for statically analyzable bracket notation (currently just literals). Makes this work:

```javascript
var fs = require("fs");
fs["readFileSync"]("filename.bin");
```

and this:

```javascript
var read = require("fs")["readFileSync"];
read("filename.bin");
```

This notation is often used by programs that are subject to minification where variable names/properties are mangled. For example, emscripten generates code like this, which is where I saw the error that happens currently.