### PR TITLE
Add support for multiple require calls in a single variable declaration

### DIFF
--- a/test/brfs.js
+++ b/test/brfs.js
@@ -81,7 +81,7 @@ test('readFileSync attribute with multiple require vars', function (t) {
     }, { vars: { __dirname: path.join(__dirname, 'brfs') } });
     readStream('multi_require.js').pipe(sm).pipe(concat(function (body) {
         t.equal(body.toString('utf8'),
-            'var x = 5'
+            'var x = 5;'
             + '\nvar src = "beep boop\\n";'
             + '\nconsole.log(src);\n'
         );

--- a/test/vars.js
+++ b/test/vars.js
@@ -70,7 +70,7 @@ test('5-var', function (t) {
 test('multi consecutive require vars', function (t) {
     t.plan(1);
     
-    var expected = [ 'beep boop12' ];
+    var expected = [ 'beep boop' ];
     var sm = staticModule({
         fs: {
             readFileSync: function (file, enc) {
@@ -80,7 +80,7 @@ test('multi consecutive require vars', function (t) {
     }, { vars: { __dirname: path.join(__dirname, 'vars') } });
     
     readStream('multi-require.js').pipe(sm).pipe(concat(function (body) {
-        Function(['console','require'],body)({ log: log }, function() {});
+        Function(['console','require'],body)({ log: log }, function() { return {} });
         function log (msg) { t.equal(msg, expected.shift()) }
     }));
 });

--- a/test/vars.js
+++ b/test/vars.js
@@ -67,6 +67,24 @@ test('5-var', function (t) {
     }));
 });
 
+test('multi consecutive require vars', function (t) {
+    t.plan(1);
+    
+    var expected = [ 'beep boop12' ];
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file, enc) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, { vars: { __dirname: path.join(__dirname, 'vars') } });
+    
+    readStream('multi-require.js').pipe(sm).pipe(concat(function (body) {
+        Function(['console','require'],body)({ log: log }, function() {});
+        function log (msg) { t.equal(msg, expected.shift()) }
+    }));
+});
+
 function readStream (file) {
     return fs.createReadStream(path.join(__dirname, 'vars', file));
 }

--- a/test/vars/multi-require.js
+++ b/test/vars/multi-require.js
@@ -1,0 +1,14 @@
+var fs = require('fs'),
+    tls = require('tls'),
+    zlib = require('zlib'),
+    Socket = require('net').Socket,
+    EventEmitter = require('events').EventEmitter,
+    inherits = require('util').inherits,
+    inspect = require('util').inspect;
+
+var foo = require('foo');
+var bar = require('bar');
+
+var html = fs.readFileSync(__dirname + '/vars.html', 'utf8');
+
+console.log(html);


### PR DESCRIPTION
 This patch fixes multiple require declarations use case:

```js
var foo = require('foo'),
    fs = require('fs'),
    bar = require('bar');

var html = fs.readFileSync('./index.html', 'utf8');
```

It makes `updates.push` the only way of patching the source code. Currently the AST is mutated as well which leads to rather complex patching code and makes it difficult to grasp and verify.

The biggest thing is that now source offsets in AST nodes are actually the same as offsets used by the patching mechanism which is both simpler and more flexible (because now it's possible to replace the compound node with some code and then append more code at the end without messing positions and offsets).

The test was provided by @mscdex in #10 (close #10).

Related brfs issue: substack/brfs#28.