### PR TITLE
Fix for multiple consecutive require vars where not all vars are initialized

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = function parse (modules, opts) {
                     
                     var s = parse(modules, {
                         skip: skip,
-                        skipOffset: skipOffset + d.init.start,
+                        skipOffset: skipOffset + (d.init ? d.init.start : 0),
                         vars: vars,
                         varNames: varNames
                     });

--- a/test/brfs.js
+++ b/test/brfs.js
@@ -92,6 +92,28 @@ test('readFileSync attribute with multiple require vars', function (t) {
     }));
 });
 
+test('readFileSync attribute with multiple require vars including an uninitalized var', function (t) {
+    t.plan(2);
+    var sm = staticModule({
+        fs: {
+            readFileSync: function (file) {
+                return fs.createReadStream(file).pipe(quote());
+            }
+        }
+    }, { vars: { __dirname: path.join(__dirname, 'brfs') } });
+    readStream('multi_require_with_uninitialized.js').pipe(sm).pipe(concat(function (body) {
+        t.equal(body.toString('utf8'),
+            'var x;'
+            + '\nvar src = "beep boop\\n";'
+            + '\nconsole.log(src);\n'
+        );
+        vm.runInNewContext(body.toString('utf8'), {
+            console: { log: log }
+        });
+        function log (msg) { t.equal(msg, 'beep boop\n') }
+    }));
+});
+
 test('readFileSync attribute with multiple require vars x5', function (t) {
     t.plan(2);
     var sm = staticModule({

--- a/test/brfs/multi_require_with_uninitialized.js
+++ b/test/brfs/multi_require_with_uninitialized.js
@@ -1,0 +1,3 @@
+var fs = require('fs'), x;
+var src = fs.readFileSync(__dirname + '/x.txt', 'utf8');
+console.log(src);


### PR DESCRIPTION
This construct fails to parse:

```javascript
var fs = require('fs'), 
    uninitialized;
```

whereas this is fine:

```javascript
var fs = require('fs'), 
    uninitialized = undefined;
```

This pull request fixes https://github.com/substack/brfs/issues/68
