### PR TITLE
Bump concat-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "convert module usage to inline expressions",
   "main": "index.js",
   "dependencies": {
-    "concat-stream": "~1.4.5",
+    "concat-stream": "~1.6.0",
     "duplexer2": "~0.0.2",
     "escodegen": "~1.3.2",
     "falafel": "^1.0.0",


### PR DESCRIPTION
I hate to be the guy who opens a PR like this. Newer versions of concat-stream contains a minor security fix that I'm pretty sure doesn't affect this module, but all the automated security audit tools don't know this. I'm tired of getting notified about this all the time, so now I'll just try to play ball - sorry.