### PR TITLE
Allow import and export statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function parse (modules, opts) {
     return duplexer(concat(function (buf) {
         try {
             body = buf.toString('utf8').replace(/^#!/, '//#!');
-            falafel(body, { ecmaVersion: 8 }, walk);
+            falafel(body, { ecmaVersion: 8, sourceType: 'module' }, walk);
         }
         catch (err) { return error(err) }
         finish(body);


### PR DESCRIPTION
Currently, static-module crashes when reading modules which use the 'import' statement. This makes it fail to parse those modules and crash with the cryptic error message:

```
'import' and 'export' may appear only with 'sourceType: module' 
```

Which after some research I found comes from acorn, which is the crashing entity here :)

(my use case, IE how this crash affects me): This failure cascades to brfs, and from then on webpack's transform-loader. Webpack 2 now supports ES6 modules, which create-react-app favours. This made webpack fail to compile my project as it uses import statements.