### PR TITLE
Add support for unary operators on modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,23 @@ module.exports = function parse (modules, opts) {
                 });
             }
         }
+        else if (node.parent.type === 'UnaryExpression') {
+            var xvars = copy(vars);
+            xvars[node.name] = val;
+
+            var res = evaluate(node.parent, xvars);
+            if (res !== undefined) {
+                updates.push({
+                    start: node.parent.start,
+                    offset: node.parent.end - node.parent.start,
+                    stream: isStream(res) ? wrapStream(res) : st(String(res))
+                });
+            } else {
+                output.emit('error', new Error(
+                    'unsupported unary operator: ' + node.parent.operator
+                ));
+            }
+        }
         else {
             output.emit('error', new Error(
                 'unsupported type for static module: ' + node.parent.type

--- a/test/unary.js
+++ b/test/unary.js
@@ -1,0 +1,33 @@
+var test = require('tape');
+var concat = require('concat-stream');
+var staticModule = require('../');
+var fs = require('fs');
+var path = require('path');
+
+test('supported unary operator', function (t) {
+    t.plan(1);
+
+    var expected = [ false ];
+    var sm = staticModule({
+        beep: { x: 42 }
+    });
+    readStream('supported.js').pipe(sm).pipe(concat(function (body) {
+        Function(['console'],body)({ log: log });
+        function log (msg) { t.equal(msg, expected.shift()) }
+    }));
+});
+
+test('unsupported unary operator', function (t) {
+    t.plan(1)
+
+    var sm = staticModule({
+        beep: { x: 42 }
+    });
+    readStream('unsupported.js').pipe(sm).on('error', function (error) {
+        t.equal(error.message, 'unsupported unary operator: typeof')
+    })
+})
+
+function readStream (file) {
+    return fs.createReadStream(path.join(__dirname, 'unary', file));
+}

--- a/test/unary/supported.js
+++ b/test/unary/supported.js
@@ -1,0 +1,2 @@
+var beep = require('beep')
+console.log(!beep)

--- a/test/unary/unsupported.js
+++ b/test/unary/unsupported.js
@@ -1,0 +1,2 @@
+var beep = require('beep')
+console.log(typeof beep)


### PR DESCRIPTION
I have been facing the same error as has been reported in #23:

```
Module build failed: Error: unsupported type for static module: UnaryExpression
at expression:

  !fs
```

This can be triggered by the following code (similar to the code that breaks in [pump](https://github.com/mafintosh/pump/blob/master/index.js#L12)):
```
var fs = require('fs')
if (!fs) console.log('browser')
```

Once the fix is applied, this will transform to:

```
if (false) console.log('browser')
```

`static-eval` currently does not support `typeof` or `delete` operators. It's unclear what should happen in that case, so I've left them 'unsupported' for now. There is a test for that case.