### PR TITLE
deps(package): Update static-eval to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "quote-stream": "~0.0.0",
     "readable-stream": "~1.0.27-1",
     "shallow-copy": "~0.0.1",
-    "static-eval": "~0.2.0",
+    "static-eval": "^2.0.0",
     "through2": "~0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://nodesecurity.io/advisories/548